### PR TITLE
Torneos la San Marqueña decodificador ver 1

### DIFF
--- a/app_file_decoder_ver_1.html
+++ b/app_file_decoder_ver_1.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title>La San Marqueña</title>
+  <style>
+    .lbl_red_text{
+      color: #ff0000;
+    }
+  </style>
+</head>
+<body>
+<h1>Decodificador de archivo de registros de Torneos la San Marqueña</h1>
+<h3>Selecciona un archivo de texto cifrado base-64, para decodificarlo en una cadena de un arreglo de objetos json</h3>
+<input type="file" id="fileInput" accept=".txt">
+<br><br>
+<label class="lbl_red_text" id="lbl_json_decode"></label>
+<p>
+  Copia el texto mostrado en rojo en la siguiente liga <a href="https://data.page/json/csv" target="_blank">Convert JSON to CSV</a> para convertir la cadena de un arreglo de objetos json a texto separado por comas
+</p>
+<script>
+  document.getElementById('fileInput').addEventListener('change', function(e) {
+      const file = e.target.files[0];
+      let str_encode_obj_json = "";
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = function(event) {
+          const content = event.target.result;
+          str_encode_obj_json = window.atob(content);
+          document.getElementById('lbl_json_decode').innerHTML = str_encode_obj_json;
+      };
+      reader.readAsText(file);
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Se agregó la opción para decodificar el texto cifrado base-64 a una cadena de un arreglo de objetos json. También se agregó la opción de una liga para convertir en línea la cadena de un arreglo de objetos json a texto separado por comas.